### PR TITLE
Implement streaming chat and clear new chats

### DIFF
--- a/bob/chatgpt.py
+++ b/bob/chatgpt.py
@@ -13,3 +13,14 @@ async def chat(messages):
         model="gpt-4", messages=messages
     )
     return response.choices[0].message["content"]
+
+
+async def stream_chat(messages):
+    """Yield the assistant response in chunks using OpenAI's streaming API."""
+    response = await openai.ChatCompletion.acreate(
+        model="gpt-4", messages=messages, stream=True
+    )
+    async for chunk in response:
+        delta = chunk.choices[0]["delta"].get("content")
+        if delta:
+            yield delta

--- a/bob/templates/home.html
+++ b/bob/templates/home.html
@@ -93,10 +93,42 @@
         {% endfor %}
       </div>
      
-      <form hx-post="/conversations/{{ active_conversation.id }}/message" hx-target="#messages" hx-swap="beforeend" class="w-full mt-8 flex gap-2">
+      <form hx-post="/conversations/{{ active_conversation.id }}/message" hx-target="#messages" hx-swap="beforeend" hx-on="htmx:afterRequest:this.reset()" class="w-full mt-8 flex gap-2">
         <input type="text" name="text" placeholder="Message Bob..." class="flex-1 px-4 py-3 rounded-xl bg-[#f1f2f4] border-none focus:ring-0 text-[#121416] text-base" />
         <button type="submit" class="bg-[#dce8f3] text-[#121416] px-6 py-2 rounded-full font-semibold text-sm">Send</button>
       </form>
+
+      <script>
+        function startStream(convId, msgId) {
+          const container = document.getElementById('messages');
+          const wrapper = document.createElement('div');
+          wrapper.className = 'flex items-start gap-3';
+          wrapper.innerHTML = `<div class="w-10 h-10 flex items-center justify-center rounded-full bg-[#f1f2f4]">
+  <svg viewBox="0 0 48 48" width="36" height="36" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <ellipse cx="24" cy="28" rx="14" ry="10" fill="#fff" stroke="#121416" stroke-width="2"/>
+    <ellipse cx="24" cy="14" rx="7" ry="6" fill="#fff" stroke="#121416" stroke-width="2"/>
+    <ellipse cx="21.5" cy="13" rx="1.2" ry="1.2" fill="#121416"/>
+    <path d="M31 13c2.5-2 6 2 3 4" stroke="#ffa726" stroke-width="2" fill="none"/>
+    <path d="M30 13c2-1 5 2 2.2 3.3" stroke="#ffa726" stroke-width="2" fill="none"/>
+    <path d="M29 15l2 1" stroke="#ffa726" stroke-width="2" fill="none"/>
+  </svg>
+</div>
+<div>
+  <div class="text-[#6a7681] text-xs mb-1">Bob</div>
+  <div class="bg-[#f1f2f4] rounded-xl px-4 py-3 text-[#121416] max-w-xl"><span class="bob-text"></span></div>
+</div>`;
+          container.appendChild(wrapper);
+          const textSpan = wrapper.querySelector('.bob-text');
+          const source = new EventSource(`/conversations/${convId}/stream?user_msg_id=${msgId}`);
+          source.onmessage = (event) => {
+            if (event.data === '[DONE]') {
+              source.close();
+            } else {
+              textSpan.textContent += event.data;
+            }
+          };
+        }
+      </script>
   
     </section>
   </main>

--- a/bob/templates/partials/new_conversation.html
+++ b/bob/templates/partials/new_conversation.html
@@ -1,0 +1,2 @@
+{% include 'partials/conversation_link.html' %}
+<div id="messages" hx-swap-oob="true"></div>

--- a/bob/templates/partials/user_message_and_stream.html
+++ b/bob/templates/partials/user_message_and_stream.html
@@ -1,0 +1,2 @@
+{% include 'partials/message_item.html' %}
+<script>startStream({{ conv_id }}, {{ msg.id }});</script>

--- a/bob/web.py
+++ b/bob/web.py
@@ -1,7 +1,7 @@
 # Part of Bob: an AI-driven learning and productivity portal for individuals and organizations | Copyright (c) 2025 | License: MIT
 
 from fastapi import FastAPI, Request, Form, Depends
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from .db import SessionLocal, engine
 from .models import Base, User, Conversation, Message
 from .schemas import MessageCreate
-from .chatgpt import chat
+from .chatgpt import stream_chat
 
 Base.metadata.create_all(bind=engine)
 
@@ -93,32 +93,54 @@ async def read_conversation(conv_id: int, request: Request, db: Session = Depend
 
 @app.post("/conversations/{conv_id}/message", response_class=HTMLResponse)
 async def send_message(conv_id: int, text: str = Form(...), db: Session = Depends(get_db)):
+    """Store the user message and initiate streaming of the assistant reply."""
     conv = db.query(Conversation).filter(Conversation.id == conv_id).first()
     if not conv:
         return ""
+
     user_msg = Message(conversation_id=conv.id, sender="user", text=text)
     db.add(user_msg)
     db.commit()
     db.refresh(user_msg)
 
-    messages = [
-        {"role": "system", "content": "You are Bob, an AI assistant."},
-    ]
-    for msg in conv.messages:
+    return templates.TemplateResponse(
+        "partials/user_message_and_stream.html",
+        {"request": {}, "msg": user_msg, "conv_id": conv.id},
+    )
+
+
+@app.get("/conversations/{conv_id}/stream")
+async def stream_response(conv_id: int, user_msg_id: int, db: Session = Depends(get_db)):
+    """Stream the assistant response for the given conversation."""
+    conv = db.query(Conversation).filter(Conversation.id == conv_id).first()
+    user_msg = db.query(Message).filter(Message.id == user_msg_id).first()
+    if not conv or not user_msg:
+        async def empty():
+            yield "data: [DONE]\n\n"
+        return StreamingResponse(empty(), media_type="text/event-stream")
+
+    history = (
+        db.query(Message)
+        .filter(Message.conversation_id == conv.id)
+        .order_by(Message.created_at)
+        .all()
+    )
+    messages = [{"role": "system", "content": "You are Bob, an AI assistant."}]
+    for msg in history:
         role = "assistant" if msg.sender == "bob" else "user"
         messages.append({"role": role, "content": msg.text})
-    messages.append({"role": "user", "content": text})
 
-    bob_response = await chat(messages)
-    bob_msg = Message(conversation_id=conv.id, sender="bob", text=bob_response)
-    db.add(bob_msg)
-    db.commit()
-    db.refresh(bob_msg)
+    async def event_generator():
+        full_text = ""
+        async for chunk in stream_chat(messages):
+            full_text += chunk
+            yield f"data: {chunk}\n\n"
+        yield "data: [DONE]\n\n"
+        bob_msg = Message(conversation_id=conv.id, sender="bob", text=full_text)
+        db.add(bob_msg)
+        db.commit()
 
-    return templates.TemplateResponse(
-        "partials/messages.html",
-        {"request": {}, "messages": [user_msg, bob_msg]},
-    )
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
 @app.post("/new-conversation", response_class=HTMLResponse)
@@ -129,7 +151,7 @@ async def new_conversation(request: Request, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(conv)
     return templates.TemplateResponse(
-        "partials/conversation_link.html",
+        "partials/new_conversation.html",
         {"request": request, "conv": conv},
     )
 


### PR DESCRIPTION
## Summary
- support streaming responses from OpenAI using server-sent events
- update client-side script to start EventSource streams
- reset chat input after sending
- clear messages when starting a new conversation

## Testing
- `python -m py_compile bob/chatgpt.py bob/web.py`


------
https://chatgpt.com/codex/tasks/task_e_683b85a69aac832e96a3f986a8353278