### PR TITLE
Implement Settings provider and dynamic agents

### DIFF
--- a/bob/settings.py
+++ b/bob/settings.py
@@ -1,35 +1,88 @@
-# Part of Bob: an AI-driven learning and productivity portal for individuals and organizations | Copyright (c) 2025 | License: MIT
+from __future__ import annotations
+
+"""Project configuration utilities."""
 
 from functools import lru_cache
+from pathlib import Path
+from typing import Protocol, Optional, List, Dict
 import os
+import tomllib
 
-from dotenv import load_dotenv
 
-load_dotenv()
+class SettingsProvider(Protocol):
+    """Protocol for loading configuration data."""
+
+    def load(self, path: str) -> Dict:
+        """Load a configuration file and return a dictionary."""
+        ...
+
+
+class TomlSettingsProvider:
+    """Load settings from a TOML file."""
+
+    def load(self, path: str) -> Dict:
+        with open(path, "rb") as fh:
+            return tomllib.load(fh)
 
 
 class Settings:
-    DATABASE_URL: str
-    OPENAI_API_KEY: str | None
-    OPENAI_MODEL: str
-    HOST: str
-    PORT: int
-    LLM_PROVIDER: str
-    REDIS_URL: str
+    """Application settings with pluggable configuration provider.
 
-    def __init__(self):
+    Usage example::
+
+        settings = Settings()
+        print(settings.get_agent_names())
+    """
+
+    def __init__(self, provider: Optional[SettingsProvider] = None, path: Optional[str] = None) -> None:
+        self._provider = provider or TomlSettingsProvider()
+        self._path = self._discover_path(path)
+        data: Dict = {}
+        if self._path:
+            try:
+                data = self._provider.load(self._path)
+            except Exception:
+                data = {}
+        self._agents: Dict[str, Dict] = data.get("agents", {})
+
+        # Legacy environment settings
         self.DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./db/bob.db")
-        self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", None)
         self.OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
         self.HOST = os.getenv("HOST", "0.0.0.0")
         self.PORT = int(os.getenv("PORT", 8000))
-        self.LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")
         self.REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+        self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY") or self.get_agent_param("default", "openai_api_key")
+        self.LLM_PROVIDER = os.getenv("LLM_PROVIDER", self.get_agent_param("default", "llm", "openai"))
+
+    def _discover_path(self, path: Optional[str]) -> Optional[str]:
+        candidates: List[Path] = []
+        if path:
+            candidates.append(Path(path))
+        env = os.getenv("bob_config_path")
+        if env:
+            candidates.append(Path(env))
+        if not candidates:
+            for name in ("bob-config.toml", "bobconfig.toml", "bob.toml"):
+                candidates.append(Path.cwd() / name)
+        for p in candidates:
+            if p.is_file():
+                return str(p)
+        return None
+
+    def get_agent_names(self) -> List[str]:
+        return list(self._agents.keys())
+
+    def get_agent(self, name: str) -> Dict:
+        return self._agents.get(name, {})
+
+    def get_agent_param(self, name: str, param: str, default=None):
+        return self.get_agent(name).get(param, default)
 
 
 @lru_cache(maxsize=1)
-def get_settings() -> Settings:
-    return Settings()
+def get_settings(provider: Optional[SettingsProvider] = None, path: Optional[str] = None) -> Settings:
+    return Settings(provider, path)
 
 
 settings = get_settings()

--- a/bob/templates/home.html
+++ b/bob/templates/home.html
@@ -79,11 +79,11 @@
         {% endfor %}
       </div>
      
-      <form hx-post="/{{ active_conversation.id }}/message" hx-target="#messages" hx-swap="beforeend" hx-on="htmx:afterRequest:this.reset()" class="fixed bottom-0 left-64 right-0 bg-[#f7f8fa] px-12 py-4 flex gap-2 z-10">
+      <form hx-post="/{{ active_conversation.id }}/message" hx-target="#messages" hx-swap="beforeend" hx-on="htmx:afterRequest:document.querySelector('[name=text]').value=''" class="fixed bottom-0 left-64 right-0 bg-[#f7f8fa] px-12 py-4 flex gap-2 z-10">
         <select name="agent" class="px-3 py-2 rounded-md bg-[#f1f2f4] text-sm text-[#121416]">
-          <option value="default">Default</option>
-          <option value="Bob">Bob</option>
-          <option value="tutor">Tutor</option>
+          {% for agent in agent_names %}
+          <option value="{{ agent }}" {% if agent == active_agent %}selected{% endif %}>{{ agent }}</option>
+          {% endfor %}
         </select>
         <input type="text" name="text" placeholder="Message Bob..." class="flex-1 px-4 py-3 rounded-xl bg-[#f1f2f4] border-none focus:ring-0 text-[#121416] text-base" />
         <button type="submit" class="bg-[#dce8f3] text-[#121416] px-6 py-2 rounded-full font-semibold text-sm">Send</button>

--- a/bobbingconfig.toml
+++ b/bobbingconfig.toml
@@ -1,0 +1,17 @@
+[agents.default]
+llm = "openai"
+openai_api_key = "XXXXX"
+
+[agents.bob]
+llm = "openai"
+openai_api_key = "XXXXX"
+vector_db_type = "Chroma"
+vector_db_embedding = "openai"
+vector_db_path = "./db/chroma"
+
+[agents.tutor]
+llm = "openai"
+openai_api_key = "XXXXX"
+vector_db_type = "Chroma"
+vector_db_embedding = "openai"
+vector_db_path = "./db/chroma"


### PR DESCRIPTION
## Summary
- refactor settings to use provider protocol with TOML implementation
- load agent names from config and use them in the chat UI
- persist chosen agent in session
- expose agent config for BobAgent vector DB initialization
- include example `bobbingconfig.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6859a97cccb4832e9924ade5c571299b