### PR TITLE
Refactor settings and per-agent resources

### DIFF
--- a/bob-config.toml
+++ b/bob-config.toml
@@ -1,0 +1,26 @@
+[global]
+database_url="sqlite+aiosqlite:///./db/bob.db"
+host="0.0.0.0"
+port=8000
+redis_url="redis://localhost:6379/0"
+
+[agents.default]
+llm = "openai"
+openai_api_key = "XXXX"
+openai_model = "gpt-4.1"
+
+[agents.bob]
+llm = "openai"
+openai_api_key = "XXXX"
+openai_model = "gpt-4.1"
+vector_db_type = "Chroma"
+vector_db_embedding = "openai"
+vector_db_path = "./db/chroma"
+
+[agents.tutor]
+llm = "openai"
+openai_api_key = "XXXX"
+openai_model = "gpt-4.1"
+vector_db_type = "Chroma"
+vector_db_embedding = "openai"
+vector_db_path = "./db/chroma"

--- a/bob/llm.py
+++ b/bob/llm.py
@@ -37,17 +37,16 @@ class OpenAILLM(BaseLLM):
                 yield delta
 
 
-_provider: BaseLLM
-if settings.LLM_PROVIDER == "openai":
-    _provider = OpenAILLM(settings.OPENAI_API_KEY, settings.OPENAI_MODEL)
-else:
-    raise ValueError(f"Unsupported LLM provider: {settings.LLM_PROVIDER}")
 
 
-async def generate_text(messages: list[dict]) -> str:
-    return await _provider.generate_text(messages)
+async def generate_text(messages: list[dict], agent_name: str = "default") -> str:
+    """Generate text using the configured LLM for ``agent_name``."""
+    provider = settings.get_llm(agent_name)
+    return await provider.generate_text(messages)
 
 
-async def stream_tokens(messages: list[dict]) -> AsyncIterable[str]:
-    async for token in _provider.stream_tokens(messages):
+async def stream_tokens(messages: list[dict], agent_name: str = "default") -> AsyncIterable[str]:
+    """Stream tokens from the LLM for ``agent_name``."""
+    provider = settings.get_llm(agent_name)
+    async for token in provider.stream_tokens(messages):
         yield token

--- a/bob/settings.py
+++ b/bob/settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Protocol, Optional, List, Dict
+from typing import Protocol, Optional, List, Dict, Any
 import os
 import tomllib
 
@@ -43,17 +43,21 @@ class Settings:
                 data = self._provider.load(self._path)
             except Exception:
                 data = {}
+        self._global: Dict = data.get("global", {})
         self._agents: Dict[str, Dict] = data.get("agents", {})
 
-        # Legacy environment settings
-        self.DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./db/bob.db")
-        self.OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
-        self.HOST = os.getenv("HOST", "0.0.0.0")
-        self.PORT = int(os.getenv("PORT", 8000))
-        self.REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        # Global settings
+        self.DATABASE_URL = self._global.get("database_url", "sqlite+aiosqlite:///./db/bob.db")
+        self.HOST = self._global.get("host", "0.0.0.0")
+        self.PORT = int(self._global.get("port", 8000))
+        self.REDIS_URL = self._global.get("redis_url", "redis://localhost:6379/0")
 
-        self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY") or self.get_agent_param("default", "openai_api_key")
-        self.LLM_PROVIDER = os.getenv("LLM_PROVIDER", self.get_agent_param("default", "llm", "openai"))
+        # Environment fallbacks for agent-specific keys
+        self._env_openai_api_key = os.getenv("OPENAI_API_KEY")
+        self._env_llm_provider = os.getenv("LLM_PROVIDER")
+
+        self._llms: Dict[str, Any] = {}
+        self._vector_dbs: Dict[str, Any] = {}
 
     def _discover_path(self, path: Optional[str]) -> Optional[str]:
         candidates: List[Path] = []
@@ -78,6 +82,53 @@ class Settings:
 
     def get_agent_param(self, name: str, param: str, default=None):
         return self.get_agent(name).get(param, default)
+
+    def get_openai_api_key(self, name: str) -> Optional[str]:
+        """Return OpenAI API key for ``name`` with environment fallback."""
+        return self.get_agent_param(name, "openai_api_key", self._env_openai_api_key)
+
+    def get_llm_provider(self, name: str) -> str:
+        """Return the LLM provider configured for ``name``."""
+        return self.get_agent_param(name, "llm", self._env_llm_provider or "openai")
+
+    def get_llm(self, name: str):
+        """Return a cached LLM instance for ``name``."""
+        if name not in self._llms:
+            from .llm import OpenAILLM  # local import to avoid circular
+
+            provider = self.get_llm_provider(name)
+            if provider == "openai":
+                api_key = self.get_openai_api_key(name)
+                model = self.get_agent_param(name, "openai_model", "gpt-4.1")
+                self._llms[name] = OpenAILLM(api_key, model)
+            else:  # pragma: no cover - unsupported provider branch
+                raise ValueError(f"Unsupported LLM provider: {provider}")
+        return self._llms[name]
+
+    def get_vector_db(self, name: str):
+        """Return a cached vector DB instance for ``name`` (may be ``None``)."""
+        if name not in self._vector_dbs:
+            try:  # optional dependency
+                from langchain.embeddings import OpenAIEmbeddings
+                from langchain.vectorstores import Chroma
+            except Exception:  # pragma: no cover - optional deps
+                OpenAIEmbeddings = None
+                Chroma = None
+
+            db = None
+            db_type = self.get_agent_param(name, "vector_db_type")
+            if db_type == "Chroma" and Chroma:
+                path = self.get_agent_param(name, "vector_db_path", "chroma")
+                embedding_type = self.get_agent_param(name, "vector_db_embedding", "openai")
+                if embedding_type == "openai" and OpenAIEmbeddings:
+                    embeddings = OpenAIEmbeddings(
+                        openai_api_key=self.get_openai_api_key(name)
+                    )
+                else:  # pragma: no cover - unsupported embedding
+                    embeddings = None
+                db = Chroma(persist_directory=path, embedding_function=embeddings)
+            self._vector_dbs[name] = db
+        return self._vector_dbs[name]
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- load global settings from `bob-config.toml`
- move `openai_model` under each agent
- cache LLM and vector DB resources per agent
- adapt agent and LLM modules to use per-agent settings
- drop global `OPENAI_API_KEY` and `LLM_PROVIDER`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bob'; No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6859bdc7c704832e928b644c9f7e4784