### PR TITLE
Add conversation context menu

### DIFF
--- a/bob/conversations/middleware.py
+++ b/bob/conversations/middleware.py
@@ -113,3 +113,16 @@ async def search_conversations(db: AsyncSession, user: User, query: str) -> list
         .order_by(Conversation.created_at.desc())
     )
     return result.scalars().all()
+
+
+async def delete_conversation(db: AsyncSession, user: User, conv_id: int) -> bool:
+    """Delete a conversation owned by the given user."""
+    result = await db.execute(
+        select(Conversation).where(Conversation.id == conv_id, Conversation.user_id == user.id)
+    )
+    conv = result.scalars().first()
+    if not conv:
+        return False
+    await db.delete(conv)
+    await db.commit()
+    return True

--- a/bob/templates/partials/conversation_item.html
+++ b/bob/templates/partials/conversation_item.html
@@ -1,9 +1,13 @@
-<div id="conv-{{ conv.id }}" class="flex items-center gap-2">
+<div id="conv-{{ conv.id }}" class="relative group flex items-center gap-2">
   <a href="/{{ conv.id }}" class="flex flex-1 items-center gap-3 px-3 py-2 rounded-lg {% if active_conversation and active_conversation.id == conv.id %}bg-[#f1f2f4]{% else %}hover:bg-[#f1f2f4]{% endif %} cursor-pointer">
     <div>
       <p class="text-[#121416] text-sm font-medium">{{ conv.title }}</p>
       <p class="text-[#6a7681] text-xs">{{ conv.created_at.strftime('%Y-%m-%d %H:%M') }}</p>
     </div>
   </a>
-  <button type="button" class="text-xs text-[#6a7681]" onclick='openRenameModal({{ conv.id }}, {{ conv.title| tojson }})'>Rename</button>
+  <button type="button" class="hidden group-hover:block px-2 text-lg text-[#6a7681]" aria-label="Conversation menu" onclick="toggleMenu({{ conv.id }})">&#8230;</button>
+  <div id="menu-{{ conv.id }}" class="hidden absolute right-0 mt-1 w-28 bg-white border border-[#e7eaf0] rounded-lg shadow-md z-10">
+    <button type="button" class="block w-full text-left px-4 py-2 text-sm hover:bg-[#f1f2f4]" onclick='openRenameModal({{ conv.id }}, {{ conv.title|tojson }})'>Rename</button>
+    <button type="button" class="block w-full text-left px-4 py-2 text-sm hover:bg-[#f1f2f4]" onclick='deleteConversation({{ conv.id }})'>Delete</button>
+  </div>
 </div>

--- a/static/bob-client.js
+++ b/static/bob-client.js
@@ -63,3 +63,21 @@ function openRenameModal(convId, currentTitle) {
     modal.classList.add('hidden');
   };
 }
+
+function toggleMenu(convId) {
+  const menu = document.getElementById(`menu-${convId}`);
+  if (menu) {
+    menu.classList.toggle('hidden');
+  }
+}
+
+async function deleteConversation(convId) {
+  if (!confirm('Delete this conversation?')) return;
+  const resp = await fetch(`/${convId}/delete`, { method: 'POST' });
+  if (resp.ok) {
+    const element = document.getElementById(`conv-${convId}`);
+    if (element) element.remove();
+    // Always redirect to the root page to refresh the active conversation state
+    window.location.href = '/';
+  }
+}


### PR DESCRIPTION
## Summary
- implement `delete_conversation` middleware and API route
- extend frontend JS with menu toggle and delete logic
- update conversation item template to include contextual dropdown menu
- redirect to root page after deleting a conversation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685ac0d02714832e853b4e2e6d763274