### PR TITLE
Add persona_name setting

### DIFF
--- a/bob/conversations/middleware.py
+++ b/bob/conversations/middleware.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import selectinload
 from ..models import Conversation, Message, User
 from ..token_expander import expand_tokens
 from ..agents import get_agent
+from ..settings import settings
 from ..db import SessionLocal
 
 # Number of recent messages to include as conversation history
@@ -86,7 +87,8 @@ async def stream_agent_response(
         return
 
     history = await get_history(db, conv.id)
-    messages: list[dict[str, str]] = [{"role": "system", "content": "You are Bob, an AI assistant."}]
+    persona = settings.PERSONA_NAME
+    messages: list[dict[str, str]] = [{"role": "system", "content": f"You are {persona}, an AI assistant."}]
     for msg in history:
         role = "assistant" if msg.sender == "bob" else "user"
         messages.append({"role": role, "content": msg.text})

--- a/bob/settings.py
+++ b/bob/settings.py
@@ -55,6 +55,10 @@ class Settings:
         self.HOST = self._global.get("host", "0.0.0.0")
         self.PORT = int(self._global.get("port", 8000))
         self.REDIS_URL = self._global.get("redis_url", "redis://localhost:6379/0")
+        self.SITE_TITLE = self._global.get("site_title", "Bob Portal")
+        self.SITE_HEADER = self._global.get("site_header", "Phoenix")
+        self.SITE_TAGLINE = self._global.get("site_tagline", "AI-Powered Learning")
+        self.PERSONA_NAME = self._global.get("persona_name", "Bob")
 
         # Environment fallbacks for agent-specific keys
         self._env_openai_api_key = os.getenv("OPENAI_API_KEY")

--- a/bob/shared.py
+++ b/bob/shared.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from fastapi.templating import Jinja2Templates
 from fastapi import Request
+from .settings import settings
 from sqlalchemy.ext.asyncio import AsyncSession
 from .db import SessionLocal
 from .models import User
@@ -9,6 +10,7 @@ from sqlalchemy.future import select
 
 # Jinja2 templates
 templates = Jinja2Templates(directory="bob/templates")
+templates.env.globals["settings"] = settings
 
 # Home panels data
 HOME_PANELS = json.loads((Path(__file__).resolve().parent.parent / "home-panels.json").read_text())

--- a/bob/templates/home.html
+++ b/bob/templates/home.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Bob Portal</title>
+  <title>{{ settings.SITE_TITLE }}</title>
   <link rel="icon" type="image/png" href="/static/bob.png">
   <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -16,8 +16,8 @@
   <!-- Sidebar -->
   <aside class="w-64 bg-white border-r border-[#e7eaf0] flex flex-col px-6 py-6">
     <div>
-      <h1 class="text-lg font-bold text-[#121416] mb-0">Phoenix</h1>
-      <p class="text-sm text-[#6a7681] mb-8">AI-Powered Learning</p>
+      <h1 class="text-lg font-bold text-[#121416] mb-0">{{ settings.SITE_HEADER }}</h1>
+      <p class="text-sm text-[#6a7681] mb-8">{{ settings.SITE_TAGLINE }}</p>
     </div>
     <nav class="flex flex-col gap-1 mb-10">
       <a href="/" class="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[#f1f2f4] transition">
@@ -71,7 +71,7 @@
       {% endfor %}
     </section>
     <section class="flex flex-col flex-1 px-12 pb-6 pt-4">
-      <h2 class="text-[#121416] text-[28px] font-bold mb-4 mt-4">Chat with Bob</h2>
+        <h2 class="text-[#121416] text-[28px] font-bold mb-4 mt-4">Chat with {{ settings.PERSONA_NAME }}</h2>
       <div id="messages" class="flex flex-col gap-4 flex-1 overflow-y-auto pb-24">
         {% for msg in messages %}
           {% set msg = msg %}
@@ -85,7 +85,7 @@
           <option value="{{ agent[0] }}" {% if agent[0] == active_agent %}selected{% endif %}>{{ agent[1] }}</option>
           {% endfor %}
         </select>
-        <input type="text" name="text" placeholder="Message Bob..." class="flex-1 px-4 py-3 rounded-xl bg-[#f1f2f4] border-none focus:ring-0 text-[#121416] text-base" />
+          <input type="text" name="text" placeholder="Message {{ settings.PERSONA_NAME }}..." class="flex-1 px-4 py-3 rounded-xl bg-[#f1f2f4] border-none focus:ring-0 text-[#121416] text-base" />
         <button type="submit" class="bg-[#dce8f3] text-[#121416] px-6 py-2 rounded-full font-semibold text-sm">Send</button>
       </form>
       <script src="/static/bob-client.js"></script>

--- a/bob/templates/partials/message_item.html
+++ b/bob/templates/partials/message_item.html
@@ -11,7 +11,7 @@
     </svg>
   </div>
   <div>
-    <div class="text-[#6a7681] text-xs mb-1">Bob</div>
+    <div class="text-[#6a7681] text-xs mb-1">{{ settings.PERSONA_NAME }}</div>
     <div class="bg-[#f1f2f4] rounded-xl px-4 py-3 text-[#121416] max-w-xl markdown-body">{{ msg.html }}</div>
   </div>
 </div>

--- a/default-bob-config.toml
+++ b/default-bob-config.toml
@@ -3,6 +3,10 @@ database_url="sqlite+aiosqlite:///./db/bob.db"
 host="0.0.0.0"
 port=8000
 redis_url="redis://localhost:6379/0"
+site_title="Bob Portal"
+site_header="Phoenix"
+site_tagline="AI-Powered Learning"
+persona_name="Bob"
 
 [agents.default]
 agent_type = "default"


### PR DESCRIPTION
## Summary
- extend settings to include a `PERSONA_NAME`
- expose persona name in templates and middleware
- show persona name on the home page and messages
- update default config with `persona_name`

## Testing
- `npm --version`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685adb76de00832e8c90474d76da0b9f